### PR TITLE
fix return value bug

### DIFF
--- a/aop.go
+++ b/aop.go
@@ -129,6 +129,7 @@ func (p *AOP) funcWrapper(bean *Bean, methodName string, methodType reflect.Type
 				}
 				return
 			}
+			retValues = pjp.result
 		} else {
 			retValues = beanValue.MethodByName(funcInSturctName).Call(inputs)
 		}

--- a/aop.go
+++ b/aop.go
@@ -102,7 +102,7 @@ func (p *AOP) funcWrapper(bean *Bean, methodName string, methodType reflect.Type
 
 		funcInSturctName := getFuncNameByStructFuncName(methodName)
 
-		realFunc := func(args ...interface{}) Result {
+		realFunc := func(args ...interface{}) []reflect.Value {
 			values := []reflect.Value{}
 			for _, arg := range args {
 				values = append(values, reflect.ValueOf(arg))

--- a/join_point.go
+++ b/join_point.go
@@ -27,7 +27,6 @@ type JoinPointer interface {
 
 type ProceedingJoinPointer interface {
 	JoinPointer
-
 	Proceed(args ...interface{}) Result
 }
 
@@ -50,8 +49,8 @@ func (p *JoinPoint) Target() *Bean {
 }
 
 type ProceedingJoinPoint struct {
+	result []reflect.Value
 	JoinPointer
-
 	method interface{}
 }
 
@@ -78,6 +77,8 @@ func (p *ProceedingJoinPoint) Proceed(args ...interface{}) (result Result) {
 	}
 
 	rets := v.Call(vArgs)
+
+	p.result = rets
 
 	Result(rets).MapTo(func(r Result) {
 		result = r

--- a/join_point.go
+++ b/join_point.go
@@ -51,7 +51,7 @@ func (p *JoinPoint) Target() *Bean {
 type ProceedingJoinPoint struct {
 	result []reflect.Value
 	JoinPointer
-	method interface{}
+	method func(args ...interface{}) []reflect.Value
 }
 
 func (p *ProceedingJoinPoint) Args() Args {
@@ -62,27 +62,7 @@ func (p *ProceedingJoinPoint) Target() *Bean {
 	return p.JoinPointer.Target()
 }
 
-func (p *ProceedingJoinPoint) Proceed(args ...interface{}) (result Result) {
-	v := reflect.ValueOf(p.method)
-
-	if v.Type().NumIn() > 0 {
-		if len(args) == 0 {
-			args = p.JoinPointer.Args()
-		}
-	}
-
-	var vArgs []reflect.Value
-	for _, arg := range args {
-		vArgs = append(vArgs, reflect.ValueOf(arg))
-	}
-
-	rets := v.Call(vArgs)
-
-	p.result = rets
-
-	Result(rets).MapTo(func(r Result) {
-		result = r
-	})
-
-	return
+func (p *ProceedingJoinPoint) Proceed(args ...interface{}) Result {
+	p.result = p.method(args...)
+	return p.result
 }


### PR DESCRIPTION
Bug can be exposed by deleting line `aspectFoo.AddAdvice(&aop.Advice{Ordering: aop.AfterReturning, Method: "Bar", PointcutRefID: "pointcut_1"})` in example/main.go. There are two issues here. First, if round is called, `retValues` is not set, so when it is returned, it will return nil. After first change, another panic will rise complaining Result type cannot be converted to bool. In fact, here, I believe changing `ProceedingJoinPoint.method` to concrete type to store realFunc will make code much simpler.